### PR TITLE
Add optional cert to the env vars passed to authenticatedLndGrpc

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,4 +2,6 @@
 TELEGRAM_BOT_TOKEN="xxxx"
 LIGHTNING_MACAROON_B64="xxxx"
 LIGHTNING_HOST_PORT="xx.xx.xx.xx:xxxx"
+# Optional, use if your server has a self-signed cert.
+# LIGHTNING_CERT_B64="xxxx"
 PORT="8888"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Chat with [@botfather](https://telegram.me/botfather) on Telegram to create a ne
 
 ## Run Locally
 
-First copy `.env.sample` file to `.env` and fill in the required variables. You will need to provide valid credentials for an LND node and the host/port for the gRPC server.
+First copy `.env.sample` file to `.env` and fill in the required variables. You will need to provide valid base64-encoded credentials for an LND node and the host/port for the gRPC server. You may also need to provide a base64-encoded TLS cert for the server. Here are [instructions for generating the credentials](https://github.com/alexbosworth/lightning#lnd-authentication).
 
 Then use the following commands to spin up a local development environment:
 

--- a/src/components/lightning.ts
+++ b/src/components/lightning.ts
@@ -10,6 +10,7 @@ import table from 'text-table';
 export const { lnd } = authenticatedLndGrpc({
   macaroon: process.env.LIGHTNING_MACAROON_B64,
   socket: process.env.LIGHTNING_HOST_PORT,
+  cert: process.env.LIGHTNING_CERT_B64,
 });
 
 // TypeScript definitions for the interfaces defined in {lightning} library.


### PR DESCRIPTION
This is necessary for LND nodes that use self-signed certs.